### PR TITLE
WIP: fix dhcp lease to better support terraform

### DIFF
--- a/roles/terrible/tasks/network/network_Alpine_setup.yml
+++ b/roles/terrible/tasks/network/network_Alpine_setup.yml
@@ -12,15 +12,6 @@
     file_type: any
   register: interfaces
 
-- name: Remove unmanaged networks
-  replace:
-    path: "/etc/network/interfaces"
-    regexp: "^(.*){{ item.path.split('/')[-1] }}(.*)dhcp$"
-    replace: ''
-    backup: yes
-  with_items:
-    - "{{ interfaces.files | sort(attribute='path') }}"
-
 # Use traditional /etc/network/interfaces on Alpine
 - name: "Set connection setting files - Alpine"
   blockinfile:
@@ -35,7 +26,7 @@
           {% endif %}
           dns-nameservers {% for dns in item.1.dns %}{{ dns }}{% endfor %}
 
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.1.ip }} {{ item.0.path.split('/')[-1] }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.0.path.split('/')[-1] }}"
     create: yes
   register: interfaces_file
   with_together:

--- a/roles/terrible/tasks/network/network_Debian_setup.yml
+++ b/roles/terrible/tasks/network/network_Debian_setup.yml
@@ -12,18 +12,8 @@
     file_type: any
   register: interfaces
 
-- name: Remove unmanaged networks
-  replace:
-    path: "/etc/network/interfaces"
-    regexp: "^(.*){{ item.path.split('/')[-1] }}(.*)$"
-    replace: ''
-    backup: yes
-  with_items:
-    - "{{ interfaces.files | sort(attribute='path') }}"
-  when: ansible_distribution != 'Ubuntu'
-
 # Remove networks we do not manage in order to have control
-- name: Remove unmanaged networks /2
+- name: Remove unmanaged networks - Netplan
   shell: |
     find /etc/network/interfaces.d/ -type f -iname "ifcfg*" \
     {% for item in interfaces.files | sort(attribute='path') | list %} \
@@ -44,15 +34,15 @@
     path: "/etc/network/interfaces.d/ifcfg-managed-{{ network_name }}-{{ item.0.path.split('/')[-1] }}"
     mode: 0644
     block: |
-          auto {{ item.0.path.split('/')[-1] }}
-          iface {{ item.0.path.split('/')[-1] }} inet static
+      auto {{ item.0.path.split('/')[-1] }}:0
+      iface {{ item.0.path.split('/')[-1] }}:0 inet static
           address {{ item.1.ip }}/24
           {% if item.1.get('default_route', False) %}
           gateway {{ item.1.gw }}
           {% endif %}
           dns-nameservers {% for dns in item.1.dns %}{{ dns }}{% endfor %}
 
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.1.ip }} {{ item.0.path.split('/')[-1] }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.0.path.split('/')[-1] }}"
     create: yes
   register: interfaces_file
   with_together:
@@ -81,14 +71,14 @@
         version: 2
         ethernets:
           {{ item.0.path.split('/')[-1] }}:
-            dhcp4: no
+            dhcp4: yes
             addresses: [{{ item.1.ip }}/24]
       {% if item.1.get('default_route', False) %}
             gateway4: {{ item.1.gw }}
       {% endif %}
             nameservers:
               addresses: [{% for dns in item.1.dns %}{{ dns }}{% if not loop.last %},{% endif %}{% endfor %}]
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.1.ip }} {{ item.0.path.split('/')[-1] }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.0.path.split('/')[-1] }}"
     create: yes
   register: netplan_file
   with_together:

--- a/roles/terrible/tasks/network/network_FreeBSD_setup.yml
+++ b/roles/terrible/tasks/network/network_FreeBSD_setup.yml
@@ -17,11 +17,11 @@
     path: "/etc/rc.conf"
     mode: 0644
     block: |
-      ifconfig_{{ item.0 }}="inet {{ item.1.ip }} netmask 255.255.255.0"
+      ifconfig_{{ item.0 }}_alias0="inet {{ item.1.ip }} netmask 255.255.255.0"
       {% if item.1.get('default_route', False) %}
       defaultrouter="{{ item.1.gw }}"
       {% endif %}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.1.ip }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.0 }}"
     create: yes
   register: connection_file
   with_together:
@@ -39,7 +39,7 @@
       {% for dns in item.1.dns %}
       nameserver {{ dns }}
       {% endfor %}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.1.ip }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.0 }}"
     create: yes
   register: resolv_file
   with_together:

--- a/roles/terrible/tasks/network/network_RedHat_setup.yml
+++ b/roles/terrible/tasks/network/network_RedHat_setup.yml
@@ -30,7 +30,7 @@
       TYPE=Ethernet
       PROXY_METHOD=none
       BROWSER_ONLY=no
-      BOOTPROTO=none
+      BOOTPROTO=dhcp
       IPADDR="{{ item.1.ip }}"
       PREFIX=24
       DEFROUTE={% if item.1.get('default_route', False) %}yes

--- a/roles/terrible/tasks/network/network_Suse_setup.yml
+++ b/roles/terrible/tasks/network/network_Suse_setup.yml
@@ -29,7 +29,7 @@
       TYPE=Ethernet
       PROXY_METHOD='none'
       BROWSER_ONLY='no'
-      BOOTPROTO='static'
+      BOOTPROTO='dhcp'
       IPADDR='{{ item.1.ip }}/24'
       PREFIX='24'
       DEFROUTE={% if item.1.get('default_route', False) %}'yes'


### PR DESCRIPTION
Fix #68 

To fix this behavior, we try to enable on the NAT interface **both** dhcp + static ip, so we are sure that the desired IP is set (static) and that a dhcp lease is issued to let terraform talk to the VM on later runs.